### PR TITLE
Allows users to define GatewayClasses using any controller

### DIFF
--- a/internal/kgateway/controller/controller.go
+++ b/internal/kgateway/controller/controller.go
@@ -49,7 +49,7 @@ type GatewayConfig struct {
 	Mgr manager.Manager
 	// Dev enables development mode for the controller.
 	Dev bool
-	// ControllerName is the name of the controller. Any GatewayClass objects
+	// ControllerName is the name of the Envoy controller. Any GatewayClass objects
 	// managed by this controller must have this name as their ControllerName.
 	ControllerName string
 	// AgwControllerName is the name of the agentgateway controller. Any GatewayClass objects
@@ -207,6 +207,7 @@ func (c *controllerBuilder) watchGw(ctx context.Context) error {
 		GatewayClassName:           c.cfg.GatewayClassName,
 		WaypointGatewayClassName:   c.cfg.WaypointGatewayClassName,
 		AgentgatewayClassName:      c.cfg.AgentgatewayClassName,
+		EnvoyControllerName:        c.cfg.ControllerName,
 		AgentgatewayControllerName: c.cfg.AgwControllerName,
 	}
 

--- a/internal/kgateway/deployer/gateway_parameters.go
+++ b/internal/kgateway/deployer/gateway_parameters.go
@@ -203,7 +203,15 @@ func (k *kGatewayParameters) getGatewayParametersForGateway(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
-		mergedGwp = deployer.GetInMemoryGatewayParameters(gwc.GetName(), k.inputs.ImageInfo, k.inputs.GatewayClassName, k.inputs.WaypointGatewayClassName, k.inputs.AgentgatewayClassName, true)
+		mergedGwp = deployer.GetInMemoryGatewayParameters(deployer.InMemoryGatewayParametersConfig{
+			ControllerName:             string(gwc.Spec.ControllerName),
+			ClassName:                  gwc.GetName(),
+			ImageInfo:                  k.inputs.ImageInfo,
+			WaypointClassName:          k.inputs.WaypointGatewayClassName,
+			EnvoyControllerName:        k.inputs.EnvoyControllerName,
+			AgwControllerName:          k.inputs.AgentgatewayControllerName,
+			OmitDefaultSecurityContext: true,
+		})
 	}
 	deployer.DeepMergeGatewayParameters(mergedGwp, gwp)
 	return mergedGwp, nil
@@ -222,14 +230,15 @@ func (k *kGatewayParameters) getDefaultGatewayParameters(ctx context.Context, gw
 func (k *kGatewayParameters) getGatewayParametersForGatewayClass(ctx context.Context, gwc *api.GatewayClass) (*v1alpha1.GatewayParameters, error) {
 	// Our defaults depend on OmitDefaultSecurityContext, but these are the defaults
 	// when not OmitDefaultSecurityContext:
-	defaultGwp := deployer.GetInMemoryGatewayParameters(
-		gwc.GetName(),
-		k.inputs.ImageInfo,
-		k.inputs.GatewayClassName,
-		k.inputs.WaypointGatewayClassName,
-		k.inputs.AgentgatewayClassName,
-		false,
-	)
+	defaultGwp := deployer.GetInMemoryGatewayParameters(deployer.InMemoryGatewayParametersConfig{
+		ControllerName:             string(gwc.Spec.ControllerName),
+		ClassName:                  gwc.GetName(),
+		ImageInfo:                  k.inputs.ImageInfo,
+		WaypointClassName:          k.inputs.WaypointGatewayClassName,
+		EnvoyControllerName:        k.inputs.EnvoyControllerName,
+		AgwControllerName:          k.inputs.AgentgatewayControllerName,
+		OmitDefaultSecurityContext: false,
+	})
 
 	paramRef := gwc.Spec.ParametersRef
 	if paramRef == nil {
@@ -268,14 +277,15 @@ func (k *kGatewayParameters) getGatewayParametersForGatewayClass(ctx context.Con
 	// correctly set when they aren't overridden by the GatewayParameters.
 	mergedGwp := defaultGwp
 	if ptr.Deref(gwp.Spec.Kube.GetOmitDefaultSecurityContext(), false) {
-		mergedGwp = deployer.GetInMemoryGatewayParameters(
-			gwc.GetName(),
-			k.inputs.ImageInfo,
-			k.inputs.GatewayClassName,
-			k.inputs.WaypointGatewayClassName,
-			k.inputs.AgentgatewayClassName,
-			true,
-		)
+		mergedGwp = deployer.GetInMemoryGatewayParameters(deployer.InMemoryGatewayParametersConfig{
+			ControllerName:             string(gwc.Spec.ControllerName),
+			ClassName:                  gwc.GetName(),
+			ImageInfo:                  k.inputs.ImageInfo,
+			WaypointClassName:          k.inputs.WaypointGatewayClassName,
+			EnvoyControllerName:        k.inputs.EnvoyControllerName,
+			AgwControllerName:          k.inputs.AgentgatewayControllerName,
+			OmitDefaultSecurityContext: true,
+		})
 	}
 	deployer.DeepMergeGatewayParameters(mergedGwp, gwp)
 	return mergedGwp, nil

--- a/internal/kgateway/deployer/gateway_parameters_test.go
+++ b/internal/kgateway/deployer/gateway_parameters_test.go
@@ -444,9 +444,11 @@ func defaultInputs(t *testing.T, objs ...client.Object) *deployer.Inputs {
 			Registry: "foo",
 			Tag:      "bar",
 		},
-		GatewayClassName:         wellknown.DefaultGatewayClassName,
-		WaypointGatewayClassName: wellknown.DefaultWaypointClassName,
-		AgentgatewayClassName:    wellknown.DefaultAgwClassName,
+		GatewayClassName:           wellknown.DefaultGatewayClassName,
+		WaypointGatewayClassName:   wellknown.DefaultWaypointClassName,
+		AgentgatewayClassName:      wellknown.DefaultAgwClassName,
+		EnvoyControllerName:        wellknown.DefaultGatewayControllerName,
+		AgentgatewayControllerName: wellknown.DefaultAgwControllerName,
 	}
 }
 

--- a/pkg/deployer/deployer_test.go
+++ b/pkg/deployer/deployer_test.go
@@ -2007,7 +2007,15 @@ var _ = Describe("Deployer", func() {
 
 			// assert istio container
 			istioContainer := dep.Spec.Template.Spec.Containers[2]
-			defaultIstioVersion := *deployer.GetInMemoryGatewayParameters("a", &deployer.ImageInfo{}, "b", "c", "d", true).Spec.Kube.Istio.IstioProxyContainer.Image.Tag
+			defaultIstioVersion := *deployer.GetInMemoryGatewayParameters(deployer.InMemoryGatewayParametersConfig{
+				ControllerName:             "kgateway.dev/a",
+				ClassName:                  "a",
+				ImageInfo:                  &deployer.ImageInfo{},
+				WaypointClassName:          "b",
+				EnvoyControllerName:        "kgateway.dev/kgateway",
+				AgwControllerName:          "c",
+				OmitDefaultSecurityContext: true,
+			}).Spec.Kube.Istio.IstioProxyContainer.Image.Tag
 			helpTestImage(expectedGwp.Istio.IstioProxyContainer.Image, istioContainer, defaultIstioVersion)
 			Expect(istioContainer.Resources.Limits.Cpu()).To(Equal(expectedGwp.Istio.IstioProxyContainer.Resources.Limits.Cpu()))
 			Expect(istioContainer.Resources.Requests.Cpu()).To(Equal(expectedGwp.Istio.IstioProxyContainer.Resources.Requests.Cpu()))

--- a/pkg/deployer/gateway_parameters.go
+++ b/pkg/deployer/gateway_parameters.go
@@ -24,6 +24,7 @@ type Inputs struct {
 	GatewayClassName           string
 	WaypointGatewayClassName   string
 	AgentgatewayClassName      string
+	EnvoyControllerName        string
 	AgentgatewayControllerName string
 }
 
@@ -108,18 +109,32 @@ func applyFloatingUserId(dstKube *v1alpha1.KubernetesProxyConfig) {
 	}
 }
 
-// GetInMemoryGatewayParameters returns an in-memory GatewayParameters based on the name of the gateway class.
-func GetInMemoryGatewayParameters(name string, imageInfo *ImageInfo, gatewayClassName, waypointClassName, agentgatewayClassName string, omitDefaultSecurityContext bool) *v1alpha1.GatewayParameters {
-	switch name {
-	case waypointClassName:
-		return defaultWaypointGatewayParameters(imageInfo, omitDefaultSecurityContext)
-	case gatewayClassName:
-		return defaultGatewayParameters(imageInfo, omitDefaultSecurityContext)
-	case agentgatewayClassName:
-		return defaultAgentgatewayParameters(imageInfo, omitDefaultSecurityContext)
-	default:
-		return defaultGatewayParameters(imageInfo, omitDefaultSecurityContext)
+// InMemoryGatewayParametersConfig holds the configuration for creating in-memory GatewayParameters.
+type InMemoryGatewayParametersConfig struct {
+	ControllerName             string
+	ClassName                  string
+	ImageInfo                  *ImageInfo
+	WaypointClassName          string
+	EnvoyControllerName        string
+	AgwControllerName          string
+	OmitDefaultSecurityContext bool
+}
+
+// GetInMemoryGatewayParameters returns an in-memory GatewayParameters.
+// Controller name takes priority. This allows users to define their own
+// GatewayClass that acts very much like a built-in class but is not an
+// exact name match.
+func GetInMemoryGatewayParameters(cfg InMemoryGatewayParametersConfig) *v1alpha1.GatewayParameters {
+	if cfg.ControllerName == cfg.AgwControllerName {
+		return defaultAgentgatewayParameters(cfg.ImageInfo, cfg.OmitDefaultSecurityContext)
 	}
+	if cfg.ControllerName == cfg.EnvoyControllerName {
+		return defaultGatewayParameters(cfg.ImageInfo, cfg.OmitDefaultSecurityContext)
+	}
+	if cfg.ClassName == cfg.WaypointClassName {
+		return defaultWaypointGatewayParameters(cfg.ImageInfo, cfg.OmitDefaultSecurityContext)
+	}
+	return defaultGatewayParameters(cfg.ImageInfo, cfg.OmitDefaultSecurityContext)
 }
 
 // defaultAgentgatewayParameters returns an in-memory GatewayParameters with default values

--- a/pkg/deployer/gateway_parameters_test.go
+++ b/pkg/deployer/gateway_parameters_test.go
@@ -1,0 +1,108 @@
+package deployer_test
+
+import (
+	"testing"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/deployer"
+)
+
+// TestGetInMemoryGatewayParameters_ControllerNamePriority tests that the controller name
+// takes priority over the class name when determining which gateway parameters to return.
+func TestGetInMemoryGatewayParameters_ControllerNamePriority(t *testing.T) {
+	imageInfo := &deployer.ImageInfo{
+		Registry:   "test-registry",
+		Tag:        "test-tag",
+		PullPolicy: "IfNotPresent",
+	}
+
+	const (
+		envoyController = "kgateway.dev/kgateway"
+		agwController   = "kgateway.dev/agentgateway"
+		waypointClass   = "waypoint"
+	)
+
+	tests := []struct {
+		name                 string
+		controllerName       string
+		className            string
+		expectedAgwEnabled   bool
+		expectedServicePorts int // waypoint has an extra port
+		description          string
+	}{
+		{
+			name:                 "agentgateway controller name - ignores class name",
+			controllerName:       agwController,
+			className:            waypointClass, // should be ignored
+			expectedAgwEnabled:   true,
+			expectedServicePorts: 0,
+			description:          "When controller name matches agentgateway, it should return agentgateway parameters regardless of class name",
+		},
+		{
+			name:                 "envoy controller name - ignores waypoint class name",
+			controllerName:       envoyController,
+			className:            waypointClass, // should be ignored
+			expectedAgwEnabled:   false,
+			expectedServicePorts: 0,
+			description:          "When controller name matches envoy controller, it should return default gateway parameters and ignore the waypoint class name",
+		},
+		{
+			name:                 "waypoint class name - no controller match",
+			controllerName:       "some.other/controller",
+			className:            waypointClass,
+			expectedAgwEnabled:   false,
+			expectedServicePorts: 1, // waypoint adds a mesh port
+			description:          "When controller name doesn't match known controllers, it should check class name for waypoint",
+		},
+		{
+			name:                 "default - no matches",
+			controllerName:       "some.other/controller",
+			className:            "some-other-class",
+			expectedAgwEnabled:   false,
+			expectedServicePorts: 0,
+			description:          "When neither controller name nor class name match, it should return default gateway parameters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := deployer.InMemoryGatewayParametersConfig{
+				ControllerName:             tt.controllerName,
+				ClassName:                  tt.className,
+				ImageInfo:                  imageInfo,
+				WaypointClassName:          waypointClass,
+				EnvoyControllerName:        envoyController,
+				AgwControllerName:          agwController,
+				OmitDefaultSecurityContext: false,
+			}
+
+			gwp := deployer.GetInMemoryGatewayParameters(cfg)
+
+			if gwp == nil {
+				t.Fatal("GetInMemoryGatewayParameters returned nil")
+			}
+
+			// Check if agentgateway is enabled
+			if gwp.Spec.Kube == nil {
+				t.Fatal("GatewayParameters.Spec.Kube is nil")
+			}
+
+			agwEnabled := gwp.Spec.Kube.Agentgateway != nil &&
+				gwp.Spec.Kube.Agentgateway.Enabled != nil &&
+				*gwp.Spec.Kube.Agentgateway.Enabled
+
+			if agwEnabled != tt.expectedAgwEnabled {
+				t.Errorf("%s: agentgateway enabled = %v, want %v", tt.description, agwEnabled, tt.expectedAgwEnabled)
+			}
+
+			// Check service ports for waypoint
+			var servicePorts int
+			if gwp.Spec.Kube.Service != nil && gwp.Spec.Kube.Service.Ports != nil {
+				servicePorts = len(gwp.Spec.Kube.Service.Ports)
+			}
+
+			if servicePorts != tt.expectedServicePorts {
+				t.Errorf("%s: service ports count = %d, want %d", tt.description, servicePorts, tt.expectedServicePorts)
+			}
+		})
+	}
+}

--- a/test/deployer/deployer_helm.go
+++ b/test/deployer/deployer_helm.go
@@ -150,9 +150,11 @@ func DefaultDeployerInputs(dt DeployerTester, commonCols *collections.CommonColl
 			Registry: "ghcr.io",
 			Tag:      "v2.1.0-dev",
 		},
-		GatewayClassName:         dt.ClassName,
-		WaypointGatewayClassName: dt.WaypointClassName,
-		AgentgatewayClassName:    dt.AgwClassName,
+		GatewayClassName:           dt.ClassName,
+		WaypointGatewayClassName:   dt.WaypointClassName,
+		AgentgatewayClassName:      dt.AgwClassName,
+		EnvoyControllerName:        dt.ControllerName,
+		AgentgatewayControllerName: dt.AgwControllerName,
 	}
 }
 

--- a/test/deployer/internal_helm_test.go
+++ b/test/deployer/internal_helm_test.go
@@ -61,6 +61,14 @@ func TestRenderHelmChart(t *testing.T) {
 			Name:      "agentgateway-infrastructure",
 			InputFile: "agentgateway-infrastructure",
 		},
+		{
+			Name:      "agentgateway-controller-but-custom-gatewayclass",
+			InputFile: "agentgateway-controller-but-custom-gatewayclass",
+		},
+		{
+			Name:      "envoy-controller-ignores-agentgateway-class-name",
+			InputFile: "envoy-controller-ignores-agentgateway-class-name",
+		},
 	}
 
 	tester := DeployerTester{

--- a/test/deployer/testdata/agentgateway-controller-but-custom-gatewayclass-out.yaml
+++ b/test/deployer/testdata/agentgateway-controller-but-custom-gatewayclass-out.yaml
@@ -1,0 +1,186 @@
+---
+# Source: agentgateway/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gw
+  annotations:
+    {}
+  labels:
+    app.kubernetes.io/instance: gw
+    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/name: gw
+    app.kubernetes.io/version: 1.0.0-ci1
+    gateway.networking.k8s.io/gateway-class-name: a-lot-like-agentgateway-but-not-named-agentgateway
+    gateway.networking.k8s.io/gateway-name: gw
+    kgateway: kube-gateway
+automountServiceAccountToken: false
+---
+# Source: agentgateway/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gw
+  annotations:
+    {}
+  labels:
+    app.kubernetes.io/instance: gw
+    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/name: gw
+    app.kubernetes.io/version: 1.0.0-ci1
+    gateway.networking.k8s.io/gateway-class-name: a-lot-like-agentgateway-but-not-named-agentgateway
+    gateway.networking.k8s.io/gateway-name: gw
+    kgateway: kube-gateway
+data:
+  config.yaml: |
+    config: {}
+---
+# Source: agentgateway/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: gw
+  annotations:
+    {}
+  labels:
+    app.kubernetes.io/instance: gw
+    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/name: gw
+    app.kubernetes.io/version: 1.0.0-ci1
+    gateway.networking.k8s.io/gateway-class-name: a-lot-like-agentgateway-but-not-named-agentgateway
+    gateway.networking.k8s.io/gateway-name: gw
+    kgateway: kube-gateway
+spec:
+  type: LoadBalancer
+  ports:
+    - name: listener-8080
+      protocol: TCP
+      targetPort: 8080
+      port: 8080
+  selector:
+    app.kubernetes.io/name: gw
+    app.kubernetes.io/instance: gw
+    gateway.networking.k8s.io/gateway-name: gw
+---
+# Source: agentgateway/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gw
+  annotations:
+  labels:
+    app.kubernetes.io/instance: gw
+    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/name: gw
+    app.kubernetes.io/version: 1.0.0-ci1
+    gateway.networking.k8s.io/gateway-class-name: a-lot-like-agentgateway-but-not-named-agentgateway
+    gateway.networking.k8s.io/gateway-name: gw
+    kgateway: kube-gateway
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gw
+      app.kubernetes.io/instance: gw
+      gateway.networking.k8s.io/gateway-name: gw
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/instance: gw
+        app.kubernetes.io/name: gw
+        gateway.networking.k8s.io/gateway-class-name: a-lot-like-agentgateway-but-not-named-agentgateway
+        gateway.networking.k8s.io/gateway-name: gw
+    spec:
+      serviceAccountName: gw
+      securityContext:
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
+      containers:
+        - name: agent-gateway
+          image: "ghcr.io/agentgateway/agentgateway:0.10.3"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10101
+          startupProbe:
+            failureThreshold: 60
+            httpGet:
+              path: /healthz/ready
+              port: 15021
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 2
+          readinessProbe:
+            httpGet:
+              path: /healthz/ready
+              port: 15021
+            periodSeconds: 10
+          ports:
+          - containerPort: 15020
+            name: metrics
+            protocol: TCP
+          args:
+            - -f
+            - /config/config.yaml
+          env:
+            - name: TERMINATION_GRACE_PERIOD_SECONDS
+              value: "60"
+            - name: CONNECTION_MIN_TERMINATION_DEADLINE
+              value: "10s"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: GW_NAME
+              value: gw
+            - name: RUST_BACKTRACE
+              value: "1"
+            - name: RUST_LOG
+              value: info
+            - name: XDS_ADDRESS
+              value: "http://xds.cluster.local:9978"
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: GATEWAY
+              value: gw
+          volumeMounts:
+            - name: config-volume
+              mountPath: /config
+            # Make /tmp writeable, needed for pprof
+            - name: tmp
+              mountPath: /tmp
+            - name: xds-token
+              mountPath: /var/run/secrets/xds-tokens
+              readOnly: true
+      volumes:
+        - name: config-volume
+          configMap:
+            name: gw
+        - name: xds-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                audience: kgateway
+                expirationSeconds: 43200
+                path: xds-token
+        - name: tmp
+          emptyDir: {}
+      terminationGracePeriodSeconds: 60

--- a/test/deployer/testdata/agentgateway-controller-but-custom-gatewayclass.yaml
+++ b/test/deployer/testdata/agentgateway-controller-but-custom-gatewayclass.yaml
@@ -1,0 +1,30 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: kgateway
+spec:
+  controllerName: kgateway.dev/kgateway
+  description: Standard class for managing Gateway API ingress traffic.
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: a-lot-like-agentgateway-but-not-named-agentgateway
+spec:
+  controllerName: kgateway.dev/agentgateway
+  description: agentgateway but by another name
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: gw
+  namespace: default
+spec:
+  gatewayClassName: a-lot-like-agentgateway-but-not-named-agentgateway
+  listeners:
+    - protocol: HTTP
+      port: 8080
+      name: http
+      allowedRoutes:
+        namespaces:
+          from: Same

--- a/test/deployer/testdata/envoy-controller-ignores-agentgateway-class-name-out.yaml
+++ b/test/deployer/testdata/envoy-controller-ignores-agentgateway-class-name-out.yaml
@@ -1,0 +1,337 @@
+---
+# Source: kgateway-proxy/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gw
+  labels:
+    kgateway: kube-gateway
+    app.kubernetes.io/name: gw
+    app.kubernetes.io/instance: gw
+    gateway.networking.k8s.io/gateway-name: gw
+    app.kubernetes.io/version: "1.0.0-ci1"
+    gateway.networking.k8s.io/gateway-class-name: agentgateway
+    app.kubernetes.io/managed-by: kgateway
+automountServiceAccountToken: false
+---
+# Source: kgateway-proxy/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gw
+  labels:
+    kgateway: kube-gateway
+    app.kubernetes.io/name: gw
+    app.kubernetes.io/instance: gw
+    gateway.networking.k8s.io/gateway-name: gw
+    app.kubernetes.io/version: "1.0.0-ci1"
+    gateway.networking.k8s.io/gateway-class-name: agentgateway
+    app.kubernetes.io/managed-by: kgateway
+data:
+  envoy.yaml: |
+    admin:
+      address:
+        socket_address: { address: 127.0.0.1, port_value: 19000 }
+    layered_runtime:
+      layers:
+      - name: static_layer
+        static_layer:
+          envoy.restart_features.use_eds_cache_for_ads: true
+      - name: admin_layer
+        admin_layer: {}
+    node:
+      cluster: gw.default
+      metadata:
+        role: kgateway-kube-gateway-api~default~gw
+    static_resources:
+      listeners:
+      - name: readiness_listener
+        address:
+          socket_address: { address: 0.0.0.0, port_value: 8082 }
+        filter_chains:
+          - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: ingress_http
+                codec_type: AUTO
+                route_config:
+                  name: main_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains: ["*"]
+                      routes:
+                        - match:
+                            path: "/ready"
+                            headers:
+                              - name: ":method"
+                                string_match:
+                                  exact: GET
+                          route:
+                            cluster: admin_port_cluster
+                http_filters:
+                  - name: envoy.filters.http.health_check
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+                      pass_through_mode: false
+                      headers:
+                      - name: ":path"
+                        string_match:
+                          exact: "/envoy-hc"
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      - name: prometheus_listener
+        address:
+          socket_address:
+            address: 0.0.0.0
+            port_value: 9091
+        filter_chains:
+          - filters:
+              - name: envoy.filters.network.http_connection_manager
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                  codec_type: AUTO
+                  stat_prefix: prometheus
+                  route_config:
+                    name: prometheus_route
+                    virtual_hosts:
+                      - name: prometheus_host
+                        domains:
+                          - "*"
+                        routes:
+                          - match:
+                              path: "/ready"
+                              headers:
+                                - name: ":method"
+                                  string_match:
+                                    exact: GET
+                            route:
+                              cluster: admin_port_cluster
+                          - match:
+                              prefix: "/metrics"
+                              headers:
+                                - name: ":method"
+                                  string_match:
+                                    exact: GET
+                            route:
+                              prefix_rewrite: /stats/prometheus?usedonly
+                              cluster: admin_port_cluster
+                          - match:
+                              prefix: "/stats"
+                              headers:
+                                - name: ":method"
+                                  string_match:
+                                    exact: GET
+                            route:
+                              prefix_rewrite: /stats
+                              cluster: admin_port_cluster
+                  http_filters:
+                    - name: envoy.filters.http.router
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      clusters:
+        - name: xds_cluster
+          alt_stat_name: xds_cluster
+          connect_timeout: 5.000s
+          load_assignment:
+            cluster_name: xds_cluster
+            endpoints:
+            - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: xds.cluster.local
+                      port_value: 9977
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+              http_filters:
+              - name: transform
+                typed_config:
+                  "@type": type.googleapis.com/envoy.api.v2.filter.http.FilterTransformations
+                  transformations:
+                  - match:
+                      prefix: "/"
+                    route_transformations:
+                      request_transformation:
+                        transformation_template:
+                          headers:
+                            authorization: {"text": 'Bearer {{ "{{ trim(data_source(\"token\")) -}}" }}'}
+                          passthrough: {}
+                          data_sources:
+                            token:
+                              filename: "/var/run/secrets/tokens/xds-token"
+                              watched_directory:
+                                path: "/var/run/secrets/tokens"
+              - name: envoy.filters.http.upstream_codec
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec
+          upstream_connection_options:
+            tcp_keepalive:
+              keepalive_time: 10
+          cluster_type:
+            name: envoy.cluster.strict_dns
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+              respect_dns_ttl: true
+        - name: admin_port_cluster
+          connect_timeout: 5.000s
+          type: STATIC
+          lb_policy: ROUND_ROBIN
+          load_assignment:
+            cluster_name: admin_port_cluster
+            endpoints:
+            - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 19000
+    dynamic_resources:
+      ads_config:
+        transport_api_version: V3
+        api_type: GRPC
+        rate_limit_settings: {}
+        grpc_services:
+        - envoy_grpc:
+            cluster_name: xds_cluster
+      cds_config:
+        resource_api_version: V3
+        ads: {}
+      lds_config:
+        resource_api_version: V3
+        ads: {}
+---
+# Source: kgateway-proxy/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: gw
+  labels:
+    kgateway: kube-gateway
+    app.kubernetes.io/name: gw
+    app.kubernetes.io/instance: gw
+    gateway.networking.k8s.io/gateway-name: gw
+    app.kubernetes.io/version: "1.0.0-ci1"
+    gateway.networking.k8s.io/gateway-class-name: agentgateway
+    app.kubernetes.io/managed-by: kgateway
+spec:
+  type: LoadBalancer
+  ports:
+  - name: listener-8080
+    protocol: TCP
+    targetPort: 8080
+    port: 8080
+  selector:
+    app.kubernetes.io/name: gw
+    app.kubernetes.io/instance: gw
+    gateway.networking.k8s.io/gateway-name: gw
+---
+# Source: kgateway-proxy/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gw
+  labels:
+    kgateway: kube-gateway
+    app.kubernetes.io/name: gw
+    app.kubernetes.io/instance: gw
+    gateway.networking.k8s.io/gateway-name: gw
+    app.kubernetes.io/version: "1.0.0-ci1"
+    gateway.networking.k8s.io/gateway-class-name: agentgateway
+    app.kubernetes.io/managed-by: kgateway
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gw
+      app.kubernetes.io/instance: gw
+      gateway.networking.k8s.io/gateway-name: gw
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9091"
+        prometheus.io/scrape: "true"
+      labels:
+        kgateway: kube-gateway
+        app.kubernetes.io/name: gw
+        app.kubernetes.io/instance: gw
+        gateway.networking.k8s.io/gateway-name: gw
+        gateway.networking.k8s.io/gateway-class-name: agentgateway
+    spec:
+      serviceAccountName: gw
+      containers:
+      - name: kgateway-proxy
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 10101
+        args:
+        - "--disable-hot-restart"
+        - "--service-node"
+        - $(POD_NAME).$(POD_NAMESPACE)
+        - "--log-level"
+        - "info"
+        image: "ghcr.io/envoy-wrapper:v2.1.0-dev"
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+        - name: xds-token
+          mountPath: /var/run/secrets/tokens
+          readOnly: true
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: ENVOY_UID
+          value: "0"
+        ports:
+        - name: listener-8080
+          protocol: TCP
+          containerPort: 8080
+        - name: http-monitoring
+          containerPort: 9091
+        startupProbe:
+          failureThreshold: 60
+          httpGet:
+            path: /ready
+            port: 8082
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 2
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8082
+          periodSeconds: 10
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - wget --post-data "" -O /dev/null 127.0.0.1:19000/healthcheck/fail; sleep 10
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - name: xds-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: kgateway
+              expirationSeconds: 43200
+              path: xds-token
+      - configMap:
+          name: gw
+        name: envoy-config

--- a/test/deployer/testdata/envoy-controller-ignores-agentgateway-class-name.yaml
+++ b/test/deployer/testdata/envoy-controller-ignores-agentgateway-class-name.yaml
@@ -1,0 +1,30 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: kgateway
+spec:
+  controllerName: kgateway.dev/kgateway
+  description: Standard class for managing Gateway API ingress traffic.
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: agentgateway
+spec:
+  controllerName: kgateway.dev/kgateway
+  description: Uses agentgateway class name but envoy controller - should deploy envoy, not agentgateway
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: gw
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+    - protocol: HTTP
+      port: 8080
+      name: http
+      allowedRoutes:
+        namespaces:
+          from: Same

--- a/test/kubernetes/e2e/tests/base/base_suite.go
+++ b/test/kubernetes/e2e/tests/base/base_suite.go
@@ -302,10 +302,12 @@ func newGatewayHelper(testInst *e2e.TestInstallation) *defaultGatewayHelper {
 
 		// empty is ok as we only care whether it's self-managed or not
 		&deployer.Inputs{
-			ImageInfo:                &deployer.ImageInfo{},
-			GatewayClassName:         wellknown.DefaultGatewayClassName,
-			WaypointGatewayClassName: wellknown.DefaultWaypointClassName,
-			AgentgatewayClassName:    wellknown.DefaultAgwClassName,
+			ImageInfo:                  &deployer.ImageInfo{},
+			GatewayClassName:           wellknown.DefaultGatewayClassName,
+			WaypointGatewayClassName:   wellknown.DefaultWaypointClassName,
+			AgentgatewayClassName:      wellknown.DefaultAgwClassName,
+			EnvoyControllerName:        wellknown.DefaultGatewayControllerName,
+			AgentgatewayControllerName: wellknown.DefaultAgwControllerName,
 		},
 	)
 	return &defaultGatewayHelper{gwpClient: gwpClient}


### PR DESCRIPTION
That is, we now look first at GatewayClass.spec.controllerName and only then at GatewayClass.metadata.name.

We do not lose backwards compatibility unless someone did something pathological like using Envoy's controller with a class named 'agentgateway'.