### PR TITLE
ci: more docker layer caching for fast image builds

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -9,6 +9,8 @@ env:
   VERSION: 'v1.0.0-ci1'
   GITHUB_TOKEN: ${{ github.token }} # necessary to pass upgrade tests
   ENVOYINIT_CACHE_REF: ghcr.io/${{ github.repository_owner }}/envoy-wrapper-cache
+  CONTROLLER_CACHE_REF: ghcr.io/${{ github.repository_owner }}/kgateway-cache
+  SDS_CACHE_REF: ghcr.io/${{ github.repository_owner }}/sds-cache
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,6 +10,8 @@ env:
   GITHUB_TOKEN: ${{ github.token }}
   GO_TEST_RETRIES: 2
   ENVOYINIT_CACHE_REF: ghcr.io/${{ github.repository_owner }}/envoy-wrapper-cache
+  CONTROLLER_CACHE_REF: ghcr.io/${{ github.repository_owner }}/kgateway-cache
+  SDS_CACHE_REF: ghcr.io/${{ github.repository_owner }}/sds-cache
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -3,6 +3,8 @@ name: Nightly Tests
 env:
   GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }} # necessary to pass upgrade tests
   ENVOYINIT_CACHE_REF: ghcr.io/${{ github.repository_owner }}/envoy-wrapper-cache
+  CONTROLLER_CACHE_REF: ghcr.io/${{ github.repository_owner }}/kgateway-cache
+  SDS_CACHE_REF: ghcr.io/${{ github.repository_owner }}/sds-cache
 
 on:
   schedule:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -175,6 +175,10 @@ jobs:
           name: release-notes
           path: _output
 
+      - name: Disable Docker cache for releases
+        if: ${{ needs.setup.outputs.needs_release == 'true' }}
+        run: echo "DOCKER_NO_CACHE=1" >> "$GITHUB_ENV"
+
       - name: Run goreleaser
         run: make release
         env:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -62,6 +62,9 @@ dockers:
       - "--platform=linux/arm64"
       - "--build-arg=GOARCH=arm64"
       - "--build-arg=ENVOY_IMAGE={{ .Env.ENVOY_IMAGE }}"
+      - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/kgateway-cache:arm64"
+      - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/kgateway-cache:arm64,mode=max,ignore-error=true"
+      - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--no-cache{{ end }}'
   - image_templates:
       - &controller_amd_image "{{ .Env.IMAGE_REGISTRY }}/{{ .Env.CONTROLLER_IMAGE_REPO }}:{{ .Env.VERSION }}-amd64"
     use: buildx
@@ -73,6 +76,9 @@ dockers:
       - "--platform=linux/amd64"
       - "--build-arg=GOARCH=amd64"
       - "--build-arg=ENVOY_IMAGE={{ .Env.ENVOY_IMAGE }}"
+      - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/kgateway-cache:amd64"
+      - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/kgateway-cache:amd64,mode=max,ignore-error=true"
+      - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--no-cache{{ end }}'
   - image_templates:
       - &sds_arm_image "{{ .Env.IMAGE_REGISTRY }}/{{ .Env.SDS_IMAGE_REPO }}:{{ .Env.VERSION }}-arm64"
     use: buildx
@@ -84,6 +90,9 @@ dockers:
       - "--platform=linux/arm64"
       - "--build-arg=GOARCH=arm64"
       - "--build-arg=BASE_IMAGE={{ .Env.ALPINE_BASE_IMAGE }}"
+      - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/sds-cache:arm64"
+      - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/sds-cache:arm64,mode=max,ignore-error=true"
+      - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--no-cache{{ end }}'
   - image_templates:
       - &sds_amd_image "{{ .Env.IMAGE_REGISTRY }}/{{ .Env.SDS_IMAGE_REPO }}:{{ .Env.VERSION }}-amd64"
     use: buildx
@@ -95,6 +104,9 @@ dockers:
       - "--platform=linux/amd64"
       - "--build-arg=GOARCH=amd64"
       - "--build-arg=BASE_IMAGE={{ .Env.ALPINE_BASE_IMAGE }}"
+      - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/sds-cache:amd64"
+      - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/sds-cache:amd64,mode=max,ignore-error=true"
+      - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--no-cache{{ end }}'
   - image_templates:
       - &envoyinit_arm_image "{{ .Env.IMAGE_REGISTRY }}/{{ .Env.ENVOYINIT_IMAGE_REPO }}:{{ .Env.VERSION }}-arm64"
     use: buildx
@@ -111,6 +123,7 @@ dockers:
       - "--build-arg=RUSTFORMATIONS_DIR=/internal/envoyinit"
       - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/envoy-wrapper-cache:arm64"
       - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/envoy-wrapper-cache:arm64,mode=max,ignore-error=true"
+      - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--no-cache{{ end }}'
     extra_files:
       - cmd/envoyinit/docker-entrypoint.sh
       - internal/envoyinit
@@ -129,6 +142,7 @@ dockers:
       - "--build-arg=RUSTFORMATIONS_DIR=/internal/envoyinit"
       - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/envoy-wrapper-cache:amd64"
       - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/envoy-wrapper-cache:amd64,mode=max,ignore-error=true"
+      - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--no-cache{{ end }}'
     extra_files:
       - cmd/envoyinit/docker-entrypoint.sh
       - internal/envoyinit

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -58,12 +58,12 @@ dockers:
     goos: linux
     goarch: arm64
     build_flag_templates:
-      - "--pull"
       - "--platform=linux/arm64"
       - "--build-arg=GOARCH=arm64"
       - "--build-arg=ENVOY_IMAGE={{ .Env.ENVOY_IMAGE }}"
       - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/kgateway-cache:arm64"
       - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/kgateway-cache:arm64,mode=max,ignore-error=true"
+      - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--pull{{ end }}'
       - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--no-cache{{ end }}'
   - image_templates:
       - &controller_amd_image "{{ .Env.IMAGE_REGISTRY }}/{{ .Env.CONTROLLER_IMAGE_REPO }}:{{ .Env.VERSION }}-amd64"
@@ -72,12 +72,12 @@ dockers:
     goos: linux
     goarch: amd64
     build_flag_templates:
-      - "--pull"
       - "--platform=linux/amd64"
       - "--build-arg=GOARCH=amd64"
       - "--build-arg=ENVOY_IMAGE={{ .Env.ENVOY_IMAGE }}"
       - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/kgateway-cache:amd64"
       - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/kgateway-cache:amd64,mode=max,ignore-error=true"
+      - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--pull{{ end }}'
       - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--no-cache{{ end }}'
   - image_templates:
       - &sds_arm_image "{{ .Env.IMAGE_REGISTRY }}/{{ .Env.SDS_IMAGE_REPO }}:{{ .Env.VERSION }}-arm64"
@@ -86,12 +86,12 @@ dockers:
     goos: linux
     goarch: arm64
     build_flag_templates:
-      - "--pull"
       - "--platform=linux/arm64"
       - "--build-arg=GOARCH=arm64"
       - "--build-arg=BASE_IMAGE={{ .Env.ALPINE_BASE_IMAGE }}"
       - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/sds-cache:arm64"
       - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/sds-cache:arm64,mode=max,ignore-error=true"
+      - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--pull{{ end }}'
       - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--no-cache{{ end }}'
   - image_templates:
       - &sds_amd_image "{{ .Env.IMAGE_REGISTRY }}/{{ .Env.SDS_IMAGE_REPO }}:{{ .Env.VERSION }}-amd64"
@@ -100,12 +100,12 @@ dockers:
     goos: linux
     goarch: amd64
     build_flag_templates:
-      - "--pull"
       - "--platform=linux/amd64"
       - "--build-arg=GOARCH=amd64"
       - "--build-arg=BASE_IMAGE={{ .Env.ALPINE_BASE_IMAGE }}"
       - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/sds-cache:amd64"
       - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/sds-cache:amd64,mode=max,ignore-error=true"
+      - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--pull{{ end }}'
       - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--no-cache{{ end }}'
   - image_templates:
       - &envoyinit_arm_image "{{ .Env.IMAGE_REGISTRY }}/{{ .Env.ENVOYINIT_IMAGE_REPO }}:{{ .Env.VERSION }}-arm64"
@@ -114,7 +114,6 @@ dockers:
     goos: linux
     goarch: arm64
     build_flag_templates:
-      - "--pull"
       - "--platform=linux/arm64"
       - "--build-arg=GOARCH=arm64"
       - "--build-arg=ENTRYPOINT_SCRIPT=/cmd/envoyinit/docker-entrypoint.sh"
@@ -123,6 +122,7 @@ dockers:
       - "--build-arg=RUSTFORMATIONS_DIR=/internal/envoyinit"
       - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/envoy-wrapper-cache:arm64"
       - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/envoy-wrapper-cache:arm64,mode=max,ignore-error=true"
+      - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--pull{{ end }}'
       - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--no-cache{{ end }}'
     extra_files:
       - cmd/envoyinit/docker-entrypoint.sh
@@ -134,7 +134,6 @@ dockers:
     goos: linux
     goarch: amd64
     build_flag_templates:
-      - "--pull"
       - "--platform=linux/amd64"
       - "--build-arg=GOARCH=amd64"
       - "--build-arg=ENTRYPOINT_SCRIPT=/cmd/envoyinit/docker-entrypoint.sh"
@@ -142,6 +141,7 @@ dockers:
       - "--build-arg=RUSTFORMATIONS_DIR=/internal/envoyinit"
       - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/envoy-wrapper-cache:amd64"
       - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/envoy-wrapper-cache:amd64,mode=max,ignore-error=true"
+      - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--pull{{ end }}'
       - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--no-cache{{ end }}'
     extra_files:
       - cmd/envoyinit/docker-entrypoint.sh

--- a/Makefile
+++ b/Makefile
@@ -512,6 +512,10 @@ K8S_GATEWAY_SOURCES=$(call get_sources,cmd/kgateway pkg/ api/)
 CONTROLLER_OUTPUT_DIR=$(OUTPUT_DIR)/pkg/kgateway
 export CONTROLLER_IMAGE_REPO ?= kgateway
 
+# Registry cache for controller Docker build (set to enable, e.g., ghcr.io/kgateway-dev/kgateway-cache)
+CONTROLLER_CACHE_REF ?=
+CONTROLLER_CACHE_FROM := $(if $(CONTROLLER_CACHE_REF),--cache-from type=registry$(comma)ref=$(CONTROLLER_CACHE_REF),)
+
 # We include the files in K8S_GATEWAY_SOURCES as dependencies to the kgateway build
 # so changes in those directories cause the make target to rebuild
 $(CONTROLLER_OUTPUT_DIR)/kgateway-linux-$(GOARCH): $(K8S_GATEWAY_SOURCES)
@@ -528,6 +532,7 @@ $(CONTROLLER_OUTPUT_DIR)/.docker-stamp-$(VERSION)-$(GOARCH): $(CONTROLLER_OUTPUT
 	$(BUILDX_BUILD) --load $(PLATFORM) $(CONTROLLER_OUTPUT_DIR) -f $(CONTROLLER_OUTPUT_DIR)/Dockerfile \
 		--build-arg GOARCH=$(GOARCH) \
 		--build-arg ENVOY_IMAGE=$(ENVOY_IMAGE) \
+		$(CONTROLLER_CACHE_FROM) \
 		-t $(IMAGE_REGISTRY)/$(CONTROLLER_IMAGE_REPO):$(VERSION)
 	@touch $@
 
@@ -543,6 +548,10 @@ SDS_SOURCES=$(call get_sources,$(SDS_DIR))
 SDS_OUTPUT_DIR=$(OUTPUT_DIR)/$(SDS_DIR)
 export SDS_IMAGE_REPO ?= sds
 
+# Registry cache for sds Docker build (set to enable, e.g., ghcr.io/kgateway-dev/sds-cache)
+SDS_CACHE_REF ?=
+SDS_CACHE_FROM := $(if $(SDS_CACHE_REF),--cache-from type=registry$(comma)ref=$(SDS_CACHE_REF),)
+
 $(SDS_OUTPUT_DIR)/sds-linux-$(GOARCH): $(SDS_SOURCES)
 	$(GO_BUILD_FLAGS) GOOS=linux go build -ldflags='$(LDFLAGS)' -gcflags='$(GCFLAGS)' -o $@ ./cmd/sds/...
 
@@ -556,6 +565,7 @@ $(SDS_OUTPUT_DIR)/.docker-stamp-$(VERSION)-$(GOARCH): $(SDS_OUTPUT_DIR)/sds-linu
 	$(BUILDX_BUILD) --load $(PLATFORM) $(SDS_OUTPUT_DIR) -f $(SDS_OUTPUT_DIR)/Dockerfile.sds \
 		--build-arg GOARCH=$(GOARCH) \
 		--build-arg BASE_IMAGE=$(ALPINE_BASE_IMAGE) \
+		$(SDS_CACHE_FROM) \
 		-t $(IMAGE_REGISTRY)/$(SDS_IMAGE_REPO):$(VERSION)
 	@touch $@
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ export IMAGE_REGISTRY ?= ghcr.io/kgateway-dev
 # Kind of a hack to make sure _output exists
 z := $(shell mkdir -p $(OUTPUT_DIR))
 
-BUILDX_BUILD ?= docker buildx build -q
+BUILDX_BUILD ?= docker buildx build
 
 #----------------------------------------------------------------------------------
 # Devcontainer build-tools image

--- a/hack/kind/setup-kind.sh
+++ b/hack/kind/setup-kind.sh
@@ -28,11 +28,12 @@ HELM="${HELM:-go tool helm}"
 LOCALSTACK="${LOCALSTACK:-false}"
 # If true, use cloud-provider-kind instead of MetalLB for LoadBalancer support.
 CLOUD_PROVIDER_KIND="${CLOUD_PROVIDER_KIND:-false}"
-# Registry cache reference for envoyinit Docker build (optional)
+# Registry cache references for Docker builds (optional)
 ENVOYINIT_CACHE_REF="${ENVOYINIT_CACHE_REF:-}"
+CONTROLLER_CACHE_REF="${CONTROLLER_CACHE_REF:-}"
+SDS_CACHE_REF="${SDS_CACHE_REF:-}"
 
-# Export the variables so they are available in the environment
-export VERSION CLUSTER_NAME ENVOYINIT_CACHE_REF
+export VERSION CLUSTER_NAME ENVOYINIT_CACHE_REF CONTROLLER_CACHE_REF SDS_CACHE_REF
 
 function create_kind_cluster_or_skip() {
   activeClusters=$($KIND get clusters)


### PR DESCRIPTION
We use --no-cache to skip caching when cutting release images so that we re-run commands like 'apt update && apt upgrade' that would naively be cached but in fact can produce a new layer any time third-party package registries are updated.

This will make many things faster, but has a side effect of making e2e tests less flaky, too, and less costly since runner time is billed based on wall clock.