### PR TITLE
feat: per-commit release artifacts instead of mere moving tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,6 +41,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.set_vars.outputs.version }}
+      floating_version: ${{ steps.set_vars.outputs.floating_version }}
       goreleaser_args: ${{ steps.set_vars.outputs.goreleaser_args }}
       needs_release: ${{ steps.set_vars.outputs.needs_release }}
       previous_tag: ${{ steps.set_vars.outputs.previous_tag }}
@@ -53,6 +54,7 @@ jobs:
         run: |
           set -x
           GIT_SHA=$(git rev-parse --short HEAD)
+          FLOATING_VERSION=""
 
           # Validate version input for workflow_dispatch
           if [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
@@ -68,7 +70,10 @@ jobs:
             NEEDS_RELEASE=true
             GORELEASER_ARGS="--clean --skip=validate --release-notes _output/RELEASE_NOTES.md"
           elif [[ $GITHUB_REF == refs/heads/main ]]; then
-            VERSION="${MAIN_VERSION}"
+            # Per-sha version gives parallel main runs non-colliding image tags;
+            # the floating tag is promoted separately, only by the run that is still HEAD.
+            VERSION="${MAIN_VERSION}-${GIT_SHA}"
+            FLOATING_VERSION="${MAIN_VERSION}"
             NEEDS_RELEASE=false
             GORELEASER_ARGS="--clean --skip=validate"
           elif [[ $GITHUB_REF == refs/pull/* ]]; then
@@ -85,6 +90,7 @@ jobs:
           # Group redirects to satisfy shellcheck SC2129
           {
             echo "version=${VERSION}"
+            echo "floating_version=${FLOATING_VERSION}"
             echo "previous_tag=${PREVIOUS_TAG:-}"
             echo "needs_release=${NEEDS_RELEASE}"
             echo "goreleaser_args=${GORELEASER_ARGS}"
@@ -111,6 +117,21 @@ jobs:
         run: make release-charts
         env:
           VERSION: ${{ needs.setup.outputs.version }}
+          IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
+
+      - name: Promote floating charts if this commit is still main HEAD
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.setup.outputs.floating_version != '' }}
+        run: |
+          set -euo pipefail
+          git fetch origin main --depth=1
+          HEAD_SHA=$(git rev-parse origin/main)
+          if [ "${HEAD_SHA}" != "${GITHUB_SHA}" ]; then
+            echo "origin/main (${HEAD_SHA}) has moved past this commit (${GITHUB_SHA}); skipping floating chart push"
+            exit 0
+          fi
+          make release-charts
+        env:
+          VERSION: ${{ needs.setup.outputs.floating_version }}
           IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
 
   release-notes:
@@ -211,6 +232,33 @@ jobs:
                 --config "test/container-structure/${image}.yaml"
             done
           done
+
+      - name: Promote floating image tags if this commit is still main HEAD
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.setup.outputs.floating_version != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Refuse to promote if origin/main has advanced past us — whoever is newest wins.
+          git fetch origin main --depth=1
+          HEAD_SHA=$(git rev-parse origin/main)
+          if [ "${HEAD_SHA}" != "${GITHUB_SHA}" ]; then
+            echo "origin/main (${HEAD_SHA}) has moved past this commit (${GITHUB_SHA}); skipping floating tag promotion"
+            exit 0
+          fi
+          for image in kgateway sds envoy-wrapper; do
+            docker buildx imagetools create \
+              -t "${REG}/${image}:${FLOAT}" \
+              "${REG}/${image}:${VERSION}"
+            for arch in amd64 arm64; do
+              docker buildx imagetools create \
+                -t "${REG}/${image}:${FLOAT}-${arch}" \
+                "${REG}/${image}:${VERSION}-${arch}"
+            done
+          done
+        env:
+          REG: ${{ env.IMAGE_REGISTRY }}
+          VERSION: ${{ needs.setup.outputs.version }}
+          FLOAT: ${{ needs.setup.outputs.floating_version }}
 
   validate:
     name: Validate release artifacts e2e (${{ matrix.arch }})


### PR DESCRIPTION
The moving tag being `vX.Y.Z-main`, a tag for both helm chart and docker images.

Also, this is a fix: removes a race that could lead to vX.Y.Z-main pointing to an older commit than it should.