### PR TITLE
[WIP] fix: Gateway status ownership hack repaired

### DIFF
--- a/pkg/kgateway/controller/controller.go
+++ b/pkg/kgateway/controller/controller.go
@@ -13,9 +13,11 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/apiclient"
 	"github.com/kgateway-dev/kgateway/v2/pkg/deployer"
 	internaldeployer "github.com/kgateway-dev/kgateway/v2/pkg/kgateway/deployer"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
+	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
 )
 
 // rateLimiter uses token bucket for overall rate limiting and exponential backoff for per-item rate limiting
@@ -54,6 +56,9 @@ type GatewayConfig struct {
 	AdditionalGatewayClasses map[string]*deployer.GatewayClassInfo
 	// CertWatcher is the shared certificate watcher for xDS TLS
 	CertWatcher *certwatcher.CertWatcher
+	// GatewayControllerReportQueue carries Gateway status reports produced by
+	// controller/deployer reconciliation into the leader status syncer.
+	GatewayControllerReportQueue utils.AsyncQueue[reports.ReportMap]
 }
 
 type HelmValuesGeneratorOverrideFunc func(inputs *deployer.Inputs) deployer.HelmValuesGenerator

--- a/pkg/kgateway/controller/gw_controller.go
+++ b/pkg/kgateway/controller/gw_controller.go
@@ -33,10 +33,12 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
 	"github.com/kgateway-dev/kgateway/v2/pkg/deployer"
 	internaldeployer "github.com/kgateway-dev/kgateway/v2/pkg/kgateway/deployer"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+	reportssdk "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
 	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
 )
@@ -66,7 +68,8 @@ type gatewayReconciler struct {
 	svcAccountClient kclient.Client[*corev1.ServiceAccount]
 	configMapClient  kclient.Client[*corev1.ConfigMap]
 
-	controllerExtension pluginsdk.GatewayControllerExtension
+	controllerExtension      pluginsdk.GatewayControllerExtension
+	gatewayStatusReportQueue utils.AsyncQueue[reports.ReportMap]
 
 	queue controllers.Queue
 }
@@ -79,12 +82,13 @@ func NewGatewayReconciler(
 ) *gatewayReconciler {
 	filter := kclient.Filter{ObjectFilter: cfg.Client.ObjectFilter()}
 	r := &gatewayReconciler{
-		deployer:            deployer,
-		gwParams:            gwParams,
-		scheme:              cfg.Mgr.GetScheme(),
-		controllerName:      cfg.ControllerName,
-		enableEnvoy:         cfg.CommonCollections.Settings.EnableEnvoy,
-		controllerExtension: controllerExtension,
+		deployer:                 deployer,
+		gwParams:                 gwParams,
+		scheme:                   cfg.Mgr.GetScheme(),
+		controllerName:           cfg.ControllerName,
+		enableEnvoy:              cfg.CommonCollections.Settings.EnableEnvoy,
+		controllerExtension:      controllerExtension,
+		gatewayStatusReportQueue: cfg.GatewayControllerReportQueue,
 
 		gwClient:         kclient.NewFilteredDelayed[*gwv1.Gateway](cfg.Client, gvr.KubernetesGateway, filter),
 		gwClassClient:    kclient.NewFilteredDelayed[*gwv1.GatewayClass](cfg.Client, gvr.GatewayClass, filter),
@@ -315,30 +319,13 @@ func (r *gatewayReconciler) Reconcile(req types.NamespacedName) (rErr error) {
 		// if we fail to either reference a valid GatewayParameters or
 		// the GatewayParameters configuration leads to issues building the
 		// objects, we want to set the status to InvalidParameters.
-		condition := metav1.Condition{
-			Type:               string(gwv1.GatewayConditionAccepted),
-			Status:             metav1.ConditionFalse,
-			ObservedGeneration: gw.Generation,
-			Reason:             string(gwv1.GatewayReasonInvalidParameters),
-			Message:            err.Error(),
-		}
-		if statusErr := r.updateGatewayStatusWithRetry(ctx, gw, condition); statusErr != nil {
-			return fmt.Errorf("failed to update status for Gateway %s: %w", req, statusErr)
+		if statusErr := r.reportInvalidGatewayParameters(ctx, gw, err); statusErr != nil {
+			return fmt.Errorf("failed to report status for Gateway %s: %w", req, statusErr)
 		}
 		return err
-	} else if existing := meta.FindStatusCondition(gw.Status.Conditions, string(gwv1.GatewayConditionAccepted)); existing != nil &&
-		existing.Status == metav1.ConditionFalse &&
-		existing.Reason == string(gwv1.GatewayReasonInvalidParameters) {
-		// set the status Accepted=true if it had been set to false due to InvalidParameters
-		condition := metav1.Condition{
-			Type:               string(gwv1.GatewayConditionAccepted),
-			Status:             metav1.ConditionTrue,
-			ObservedGeneration: gw.Generation,
-			Reason:             string(gwv1.GatewayReasonAccepted),
-			Message:            reports.GatewayAcceptedMessage,
-		}
-		if statusErr := r.updateGatewayStatusWithRetry(ctx, gw, condition); statusErr != nil {
-			return fmt.Errorf("failed to update status for Gateway %s: %w", req, statusErr)
+	} else {
+		if statusErr := r.clearInvalidGatewayParameters(ctx, gw); statusErr != nil {
+			return fmt.Errorf("failed to report status for Gateway %s: %w", req, statusErr)
 		}
 	}
 	objs = r.deployer.SetNamespaceAndOwnerWithGVK(gw, wellknown.GatewayGVK, objs)
@@ -398,6 +385,51 @@ func (r *gatewayReconciler) updateStatus(ctx context.Context, gw *gwv1.Gateway, 
 	// update gateway addresses in the status
 	desiredAddresses := getDesiredAddresses(gw, svc)
 	return updateGatewayAddresses(ctx, r.gwClient, client.ObjectKeyFromObject(gw), desiredAddresses)
+}
+
+func (r *gatewayReconciler) reportInvalidGatewayParameters(ctx context.Context, gw *gwv1.Gateway, err error) error {
+	return r.reportGatewayStatusCondition(ctx, gw, metav1.Condition{
+		Type:               string(gwv1.GatewayConditionAccepted),
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: gw.Generation,
+		Reason:             string(gwv1.GatewayReasonInvalidParameters),
+		Message:            err.Error(),
+	})
+}
+
+func (r *gatewayReconciler) clearInvalidGatewayParameters(ctx context.Context, gw *gwv1.Gateway) error {
+	if r.gatewayStatusReportQueue == nil {
+		existing := meta.FindStatusCondition(gw.Status.Conditions, string(gwv1.GatewayConditionAccepted))
+		if existing == nil ||
+			existing.Status != metav1.ConditionFalse ||
+			existing.Reason != string(gwv1.GatewayReasonInvalidParameters) {
+			return nil
+		}
+	}
+
+	return r.reportGatewayStatusCondition(ctx, gw, metav1.Condition{
+		Type:               string(gwv1.GatewayConditionAccepted),
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: gw.Generation,
+		Reason:             string(gwv1.GatewayReasonAccepted),
+		Message:            reports.GatewayAcceptedMessage,
+	})
+}
+
+func (r *gatewayReconciler) reportGatewayStatusCondition(ctx context.Context, gw *gwv1.Gateway, condition metav1.Condition) error {
+	if r.gatewayStatusReportQueue == nil {
+		return r.updateGatewayStatusWithRetry(ctx, gw, condition)
+	}
+
+	rm := reports.NewReportMap()
+	reports.NewReporter(&rm).Gateway(gw).SetCondition(reportssdk.GatewayCondition{
+		Type:    gwv1.GatewayConditionType(condition.Type),
+		Status:  condition.Status,
+		Reason:  gwv1.GatewayConditionReason(condition.Reason),
+		Message: condition.Message,
+	})
+	r.gatewayStatusReportQueue.Enqueue(rm)
+	return nil
 }
 
 func getDesiredAddresses(gw *gwv1.Gateway, svc *corev1.Service) []gwv1.GatewayStatusAddress {

--- a/pkg/kgateway/controller/gw_controller_test.go
+++ b/pkg/kgateway/controller/gw_controller_test.go
@@ -1,0 +1,47 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
+	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
+)
+
+func TestReportInvalidGatewayParametersEnqueuesGatewayReport(t *testing.T) {
+	ctx := context.Background()
+	queue := utils.NewAsyncQueue[reports.ReportMap]()
+	gateway := &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  "default",
+			Name:       "gw",
+			Generation: 2,
+		},
+	}
+	reconciler := &gatewayReconciler{
+		gatewayStatusReportQueue: queue,
+	}
+
+	require.NoError(t, reconciler.reportInvalidGatewayParameters(ctx, gateway, errors.New("invalid parameters")))
+
+	reportMap, err := queue.Dequeue(ctx)
+	require.NoError(t, err)
+	gatewayReport := reportMap.GatewayNamespaceName(types.NamespacedName{
+		Namespace: gateway.Namespace,
+		Name:      gateway.Name,
+	})
+	require.NotNil(t, gatewayReport)
+	accepted := apimeta.FindStatusCondition(gatewayReport.GetConditions(), string(gwv1.GatewayConditionAccepted))
+	require.NotNil(t, accepted)
+	require.Equal(t, metav1.ConditionFalse, accepted.Status)
+	require.Equal(t, string(gwv1.GatewayReasonInvalidParameters), accepted.Reason)
+	require.Equal(t, "invalid parameters", accepted.Message)
+	require.Equal(t, gateway.Generation, gatewayReport.GetObservedGeneration())
+}

--- a/pkg/kgateway/controller/start.go
+++ b/pkg/kgateway/controller/start.go
@@ -166,14 +166,15 @@ func NewControllerBuilder(ctx context.Context, cfg StartConfig) (*ControllerBuil
 		}
 
 		statusSyncer := proxy_syncer.NewStatusSyncer(proxy_syncer.StatusSyncerConfig{
-			Mgr:                      cfg.Manager,
-			Plugins:                  mergedPlugins,
-			ControllerName:           cfg.ControllerName,
-			Client:                   cfg.Client,
-			ReportQueue:              proxySyncer.ReportQueue(),
-			BackendPolicyReportQueue: proxySyncer.BackendPolicyReportQueue(),
-			BackendStatusReportQueue: proxySyncer.BackendStatusReportQueue(),
-			CacheSyncs:               proxySyncer.CacheSyncs(),
+			Mgr:                          cfg.Manager,
+			Plugins:                      mergedPlugins,
+			ControllerName:               cfg.ControllerName,
+			Client:                       cfg.Client,
+			ReportQueue:                  proxySyncer.ReportQueue(),
+			GatewayControllerReportQueue: proxySyncer.GatewayControllerReportQueue(),
+			BackendPolicyReportQueue:     proxySyncer.BackendPolicyReportQueue(),
+			BackendStatusReportQueue:     proxySyncer.BackendStatusReportQueue(),
+			CacheSyncs:                   proxySyncer.CacheSyncs(),
 		}, cfg.StatusSyncerOptions...)
 		if err := cfg.Manager.Add(statusSyncer); err != nil {
 			setupLog.Error(err, "unable to add statusSyncer runnable")
@@ -263,6 +264,9 @@ func (c *ControllerBuilder) Build(ctx context.Context) error {
 		GatewayClassName:         c.cfg.GatewayClassName,
 		WaypointGatewayClassName: c.cfg.WaypointGatewayClassName,
 		CertWatcher:              c.cfg.SetupOpts.CertWatcher,
+	}
+	if c.proxySyncer != nil {
+		gwCfg.GatewayControllerReportQueue = c.proxySyncer.GatewayControllerReportQueue()
 	}
 
 	setupLog.Info("creating base gateway controller")

--- a/pkg/kgateway/proxy_syncer/proxy_syncer.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer.go
@@ -69,9 +69,10 @@ type ProxySyncer struct {
 	waitForSync []cache.InformerSynced
 	ready       atomic.Bool
 
-	reportQueue              utils.AsyncQueue[reports.ReportMap]
-	backendPolicyReportQueue utils.AsyncQueue[reports.ReportMap]
-	backendStatusReportQueue utils.AsyncQueue[reports.ReportMap]
+	reportQueue                  utils.AsyncQueue[reports.ReportMap]
+	gatewayControllerReportQueue utils.AsyncQueue[reports.ReportMap]
+	backendPolicyReportQueue     utils.AsyncQueue[reports.ReportMap]
+	backendStatusReportQueue     utils.AsyncQueue[reports.ReportMap]
 }
 
 type GatewayXdsResources struct {
@@ -165,17 +166,18 @@ func NewProxySyncer(
 	validator validator.Validator,
 ) *ProxySyncer {
 	return &ProxySyncer{
-		controllerName:           controllerName,
-		commonCols:               commonCols,
-		mgr:                      mgr,
-		apiClient:                client,
-		proxyTranslator:          NewProxyTranslator(xdsCache),
-		uniqueClients:            uniqueClients,
-		translator:               translator.NewCombinedTranslator(ctx, mergedPlugins, commonCols, validator),
-		plugins:                  mergedPlugins,
-		reportQueue:              utils.NewAsyncQueue[reports.ReportMap](),
-		backendPolicyReportQueue: utils.NewAsyncQueue[reports.ReportMap](),
-		backendStatusReportQueue: utils.NewAsyncQueue[reports.ReportMap](),
+		controllerName:               controllerName,
+		commonCols:                   commonCols,
+		mgr:                          mgr,
+		apiClient:                    client,
+		proxyTranslator:              NewProxyTranslator(xdsCache),
+		uniqueClients:                uniqueClients,
+		translator:                   translator.NewCombinedTranslator(ctx, mergedPlugins, commonCols, validator),
+		plugins:                      mergedPlugins,
+		reportQueue:                  utils.NewAsyncQueue[reports.ReportMap](),
+		gatewayControllerReportQueue: utils.NewAsyncQueue[reports.ReportMap](),
+		backendPolicyReportQueue:     utils.NewAsyncQueue[reports.ReportMap](),
+		backendStatusReportQueue:     utils.NewAsyncQueue[reports.ReportMap](),
 	}
 }
 
@@ -665,6 +667,12 @@ func (r *ProxySyncer) NeedLeaderElection() bool {
 // It will be constantly updated to contain the merged status report for Kube Gateway status.
 func (s *ProxySyncer) ReportQueue() utils.AsyncQueue[reports.ReportMap] {
 	return s.reportQueue
+}
+
+// GatewayControllerReportQueue returns the queue that contains Gateway status reports
+// produced outside translation, such as deployer/controller validation results.
+func (s *ProxySyncer) GatewayControllerReportQueue() utils.AsyncQueue[reports.ReportMap] {
+	return s.gatewayControllerReportQueue
 }
 
 // BackendPolicyReportQueue returns the queue that contains the latest status reports for all backend policies.

--- a/pkg/kgateway/proxy_syncer/status_syncer.go
+++ b/pkg/kgateway/proxy_syncer/status_syncer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/avast/retry-go/v4"
@@ -47,23 +48,30 @@ type StatusSyncer struct {
 	istioClient    apiclient.Client
 
 	latestReportQueue              utils.AsyncQueue[reports.ReportMap]
+	gatewayControllerReportQueue   utils.AsyncQueue[reports.ReportMap]
 	latestBackendPolicyReportQueue utils.AsyncQueue[reports.ReportMap]
 	latestBackendStatusReportQueue utils.AsyncQueue[reports.ReportMap]
 	cacheSyncs                     []cache.InformerSynced
 
 	customStatusSync func(ctx context.Context, rm reports.ReportMap)
+
+	gatewayStatusMu           sync.Mutex
+	latestGatewayStatusReport reports.ReportMap
+	hasGatewayStatusReport    bool
+	gatewayControllerReports  map[types.NamespacedName]*reports.GatewayReport
 }
 
 // StatusSyncerConfig holds the dependencies required to construct a StatusSyncer.
 type StatusSyncerConfig struct {
-	Mgr                      manager.Manager
-	Plugins                  plug.Plugin
-	ControllerName           string
-	Client                   apiclient.Client
-	ReportQueue              utils.AsyncQueue[reports.ReportMap]
-	BackendPolicyReportQueue utils.AsyncQueue[reports.ReportMap]
-	BackendStatusReportQueue utils.AsyncQueue[reports.ReportMap]
-	CacheSyncs               []cache.InformerSynced
+	Mgr                          manager.Manager
+	Plugins                      plug.Plugin
+	ControllerName               string
+	Client                       apiclient.Client
+	ReportQueue                  utils.AsyncQueue[reports.ReportMap]
+	GatewayControllerReportQueue utils.AsyncQueue[reports.ReportMap]
+	BackendPolicyReportQueue     utils.AsyncQueue[reports.ReportMap]
+	BackendStatusReportQueue     utils.AsyncQueue[reports.ReportMap]
+	CacheSyncs                   []cache.InformerSynced
 }
 
 func NewStatusSyncer(cfg StatusSyncerConfig, opts ...StatusSyncerOption) *StatusSyncer {
@@ -74,11 +82,95 @@ func NewStatusSyncer(cfg StatusSyncerConfig, opts ...StatusSyncerOption) *Status
 		istioClient:                    cfg.Client,
 		controllerName:                 cfg.ControllerName,
 		latestReportQueue:              cfg.ReportQueue,
+		gatewayControllerReportQueue:   cfg.GatewayControllerReportQueue,
 		latestBackendPolicyReportQueue: cfg.BackendPolicyReportQueue,
 		latestBackendStatusReportQueue: cfg.BackendStatusReportQueue,
 		cacheSyncs:                     cfg.CacheSyncs,
 		customStatusSync:               optCfg.CustomStatusSync,
+		gatewayControllerReports:       make(map[types.NamespacedName]*reports.GatewayReport),
 	}
+}
+
+func (s *StatusSyncer) gatewayStatusReportForTranslation(reportMap reports.ReportMap) reports.ReportMap {
+	s.gatewayStatusMu.Lock()
+	defer s.gatewayStatusMu.Unlock()
+
+	s.latestGatewayStatusReport = reportMap.CloneGatewayReports()
+	s.hasGatewayStatusReport = true
+	return s.mergeGatewayControllerReportsLocked(s.latestGatewayStatusReport)
+}
+
+func (s *StatusSyncer) gatewayStatusReportForControllerReport(reportMap reports.ReportMap) reports.ReportMap {
+	s.gatewayStatusMu.Lock()
+	defer s.gatewayStatusMu.Unlock()
+
+	s.applyGatewayControllerReportLocked(reportMap)
+	mergedReport := reports.NewReportMap()
+	for key, report := range reportMap.Gateways {
+		if s.hasGatewayStatusReport {
+			if latestReport := s.latestGatewayStatusReport.GatewayNamespaceName(key); latestReport != nil {
+				mergedReport.Gateways[key] = latestReport.Clone()
+			}
+		}
+		if _, exists := mergedReport.Gateways[key]; !exists {
+			mergedReport.Gateways[key] = report.Clone()
+		}
+		if controllerReport := s.gatewayControllerReports[key]; controllerReport != nil {
+			if mergedReport.Gateways[key] == nil {
+				mergedReport.Gateways[key] = controllerReport.Clone()
+				continue
+			}
+			mergeGatewayControllerReport(mergedReport.Gateways[key], controllerReport)
+		}
+	}
+	return mergedReport
+}
+
+func (s *StatusSyncer) applyGatewayControllerReportLocked(reportMap reports.ReportMap) {
+	if s.gatewayControllerReports == nil {
+		s.gatewayControllerReports = make(map[types.NamespacedName]*reports.GatewayReport)
+	}
+	for key, report := range reportMap.Gateways {
+		if !isInvalidParametersGatewayReport(report) {
+			delete(s.gatewayControllerReports, key)
+			continue
+		}
+		s.gatewayControllerReports[key] = report.Clone()
+	}
+}
+
+func (s *StatusSyncer) mergeGatewayControllerReportsLocked(reportMap reports.ReportMap) reports.ReportMap {
+	mergedReport := reportMap.CloneGatewayReports()
+	for key, controllerReport := range s.gatewayControllerReports {
+		if controllerReport == nil {
+			continue
+		}
+		gatewayReport := mergedReport.GatewayNamespaceName(key)
+		if gatewayReport == nil {
+			mergedReport.Gateways[key] = controllerReport.Clone()
+			continue
+		}
+		mergeGatewayControllerReport(gatewayReport, controllerReport)
+	}
+	return mergedReport
+}
+
+func mergeGatewayControllerReport(gatewayReport, controllerReport *reports.GatewayReport) {
+	for _, condition := range controllerReport.GetConditions() {
+		gatewayReport.SetCondition(reportssdk.GatewayCondition{
+			Type:    gwv1.GatewayConditionType(condition.Type),
+			Status:  condition.Status,
+			Reason:  gwv1.GatewayConditionReason(condition.Reason),
+			Message: condition.Message,
+		})
+	}
+}
+
+func isInvalidParametersGatewayReport(report *reports.GatewayReport) bool {
+	accepted := apimeta.FindStatusCondition(report.GetConditions(), string(gwv1.GatewayConditionAccepted))
+	return accepted != nil &&
+		accepted.Status == metav1.ConditionFalse &&
+		accepted.Reason == string(gwv1.GatewayReasonInvalidParameters)
 }
 
 func (s *StatusSyncer) Start(ctx context.Context) error {
@@ -115,7 +207,7 @@ func (s *StatusSyncer) Start(ctx context.Context) error {
 				logger.Error("failed to dequeue gateway reports", "error", err)
 				return
 			}
-			s.syncGatewayStatus(ctx, gatewayStatusLogger, latestReport)
+			s.syncGatewayStatus(ctx, gatewayStatusLogger, s.gatewayStatusReportForTranslation(latestReport))
 			s.syncListenerSetStatus(ctx, listenerSetStatusLogger, latestReport)
 			s.syncRouteStatus(ctx, routeStatusLogger, latestReport)
 			s.syncPolicyStatus(ctx, latestReport)
@@ -124,6 +216,18 @@ func (s *StatusSyncer) Start(ctx context.Context) error {
 			}
 		}
 	}()
+	if s.gatewayControllerReportQueue != nil {
+		go func() {
+			for {
+				latestReport, err := s.gatewayControllerReportQueue.Dequeue(ctx)
+				if err != nil {
+					logger.Error("failed to dequeue gateway controller reports", "error", err)
+					return
+				}
+				s.syncGatewayStatus(ctx, gatewayStatusLogger, s.gatewayStatusReportForControllerReport(latestReport))
+			}
+		}()
+	}
 	go func() {
 		for {
 			latestReport, err := s.latestBackendPolicyReportQueue.Dequeue(ctx)
@@ -507,14 +611,7 @@ func (s *StatusSyncer) syncGatewayStatus(ctx context.Context, logger *slog.Logge
 			logger.Info("updated gateway status", "gateway", gwnn.String())
 
 			for _, cond := range gw.Status.Conditions {
-				if cond.Type != string(gwv1.GatewayConditionAccepted) &&
-					cond.Type != string(gwv1.GatewayConditionProgrammed) {
-					continue
-				}
-
-				if cond.Reason != string(gwv1.GatewayReasonAccepted) &&
-					cond.Reason != string(gwv1.GatewayReasonProgrammed) &&
-					cond.Reason != string(gwv1.GatewayReasonPending) {
+				if !isKnownGatewayStatusReason(cond.Type, cond.Reason) {
 					logger.Debug("invalid status condition reason", "reason", cond.Reason, "gateway", gwnn.String())
 
 					statusErr = fmt.Errorf("invalid gateway condition")
@@ -541,6 +638,42 @@ func (s *StatusSyncer) syncGatewayStatus(ctx context.Context, logger *slog.Logge
 	}
 
 	logger.Debug("synced gw status for gateways", "count", len(rm.Gateways))
+}
+
+func isKnownGatewayStatusReason(conditionType, reason string) bool {
+	switch gwv1.GatewayConditionType(conditionType) {
+	case gwv1.GatewayConditionAccepted:
+		switch gwv1.GatewayConditionReason(reason) {
+		case gwv1.GatewayReasonAccepted,
+			gwv1.GatewayReasonPending,
+			gwv1.GatewayReasonListenersNotValid,
+			gwv1.GatewayReasonUnsupportedAddress,
+			gwv1.GatewayReasonInvalidParameters:
+			return true
+		}
+	case gwv1.GatewayConditionProgrammed:
+		switch gwv1.GatewayConditionReason(reason) {
+		case gwv1.GatewayReasonProgrammed,
+			gwv1.GatewayReasonPending,
+			gwv1.GatewayReasonAddressNotAssigned,
+			gwv1.GatewayReasonAddressNotUsable,
+			gwv1.GatewayReasonNoResources:
+			return true
+		}
+	case gwv1.GatewayConditionResolvedRefs:
+		switch gwv1.GatewayConditionReason(reason) {
+		case gwv1.GatewayReasonResolvedRefs,
+			gwv1.GatewayReasonInvalidClientCertificateRef,
+			gwv1.GatewayReasonRefNotPermitted,
+			gwv1.GatewayReasonListenersNotResolved:
+			return true
+		}
+	case gwv1.GatewayConditionInsecureFrontendValidationMode:
+		return reason == string(gwv1.GatewayReasonConfigurationChanged)
+	default:
+		return true
+	}
+	return false
 }
 
 // syncListenerSetStatus will build and update status for all Listener Sets in a reportMap

--- a/pkg/kgateway/proxy_syncer/status_syncer_gateway_test.go
+++ b/pkg/kgateway/proxy_syncer/status_syncer_gateway_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
 )
 
-func TestSyncGatewayStatusPreservesControllerInvalidParameters(t *testing.T) {
+func TestSyncGatewayStatusMergesControllerInvalidParametersReport(t *testing.T) {
 	ctx := context.Background()
 	const controllerName = "kgateway.dev/kgateway"
 	gatewayKey := types.NamespacedName{Namespace: "default", Name: "gw"}
@@ -36,15 +36,6 @@ func TestSyncGatewayStatusPreservesControllerInvalidParameters(t *testing.T) {
 				Name:     "http",
 				Port:     80,
 				Protocol: gwv1.HTTPProtocolType,
-			}},
-		},
-		Status: gwv1.GatewayStatus{
-			Conditions: []metav1.Condition{{
-				Type:               string(gwv1.GatewayConditionAccepted),
-				Status:             metav1.ConditionFalse,
-				Reason:             string(gwv1.GatewayReasonInvalidParameters),
-				Message:            "invalid gateway parameters",
-				ObservedGeneration: 2,
 			}},
 		},
 	}
@@ -69,10 +60,19 @@ func TestSyncGatewayStatusPreservesControllerInvalidParameters(t *testing.T) {
 	})
 
 	syncer := &StatusSyncer{
-		mgr:            statusSyncerTestManager{client: kubeClient},
-		controllerName: controllerName,
+		mgr:                      statusSyncerTestManager{client: kubeClient},
+		controllerName:           controllerName,
+		gatewayControllerReports: make(map[types.NamespacedName]*reports.GatewayReport),
 	}
-	syncer.syncGatewayStatus(ctx, slog.New(slog.DiscardHandler), rm)
+	controllerReport := gatewayStatusReport(gateway, reporter.GatewayCondition{
+		Type:    gwv1.GatewayConditionAccepted,
+		Status:  metav1.ConditionFalse,
+		Reason:  gwv1.GatewayReasonInvalidParameters,
+		Message: "invalid gateway parameters",
+	})
+	syncer.gatewayStatusReportForControllerReport(controllerReport)
+	mergedReport := syncer.gatewayStatusReportForTranslation(rm)
+	syncer.syncGatewayStatus(ctx, slog.New(slog.DiscardHandler), mergedReport)
 
 	updated := &gwv1.Gateway{}
 	require.NoError(t, kubeClient.Get(ctx, gatewayKey, updated))
@@ -86,6 +86,72 @@ func TestSyncGatewayStatusPreservesControllerInvalidParameters(t *testing.T) {
 	require.NotNil(t, programmed)
 	require.Equal(t, metav1.ConditionTrue, programmed.Status)
 	require.Equal(t, string(gwv1.GatewayReasonProgrammed), programmed.Reason)
+}
+
+func TestSyncGatewayStatusClearsControllerInvalidParametersReport(t *testing.T) {
+	ctx := context.Background()
+	const controllerName = "kgateway.dev/kgateway"
+	gatewayKey := types.NamespacedName{Namespace: "default", Name: "gw"}
+
+	gateway := &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  gatewayKey.Namespace,
+			Name:       gatewayKey.Name,
+			Generation: 2,
+		},
+		Spec: gwv1.GatewaySpec{
+			GatewayClassName: "kgateway",
+			Listeners: []gwv1.Listener{{
+				Name:     "http",
+				Port:     80,
+				Protocol: gwv1.HTTPProtocolType,
+			}},
+		},
+	}
+	gatewayClass := &gwv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "kgateway"},
+		Spec: gwv1.GatewayClassSpec{
+			ControllerName: gwv1.GatewayController(controllerName),
+		},
+	}
+
+	kubeClient := newFakeGatewayStatusClient(t, gateway, gatewayClass)
+	syncer := &StatusSyncer{
+		mgr:                      statusSyncerTestManager{client: kubeClient},
+		controllerName:           controllerName,
+		gatewayControllerReports: make(map[types.NamespacedName]*reports.GatewayReport),
+	}
+
+	translationReport := reports.NewReportMap()
+	reports.NewReporter(&translationReport).Gateway(gateway)
+	syncer.gatewayStatusReportForControllerReport(gatewayStatusReport(gateway, reporter.GatewayCondition{
+		Type:    gwv1.GatewayConditionAccepted,
+		Status:  metav1.ConditionFalse,
+		Reason:  gwv1.GatewayReasonInvalidParameters,
+		Message: "invalid gateway parameters",
+	}))
+
+	syncer.gatewayStatusReportForControllerReport(gatewayStatusReport(gateway, reporter.GatewayCondition{
+		Type:    gwv1.GatewayConditionAccepted,
+		Status:  metav1.ConditionTrue,
+		Reason:  gwv1.GatewayReasonAccepted,
+		Message: reports.GatewayAcceptedMessage,
+	}))
+	mergedReport := syncer.gatewayStatusReportForTranslation(translationReport)
+	syncer.syncGatewayStatus(ctx, slog.New(slog.DiscardHandler), mergedReport)
+
+	updated := &gwv1.Gateway{}
+	require.NoError(t, kubeClient.Get(ctx, gatewayKey, updated))
+	accepted := apimeta.FindStatusCondition(updated.Status.Conditions, string(gwv1.GatewayConditionAccepted))
+	require.NotNil(t, accepted)
+	require.Equal(t, metav1.ConditionTrue, accepted.Status)
+	require.Equal(t, string(gwv1.GatewayReasonAccepted), accepted.Reason)
+}
+
+func gatewayStatusReport(gateway *gwv1.Gateway, condition reporter.GatewayCondition) reports.ReportMap {
+	rm := reports.NewReportMap()
+	reports.NewReporter(&rm).Gateway(gateway).SetCondition(condition)
+	return rm
 }
 
 func newFakeGatewayStatusClient(t *testing.T, objs ...ctrlclient.Object) ctrlclient.Client {

--- a/pkg/kgateway/proxy_syncer/status_syncer_policy_test.go
+++ b/pkg/kgateway/proxy_syncer/status_syncer_policy_test.go
@@ -23,9 +23,9 @@ func TestBuildPolicyStatusPrefersPluginBuilder(t *testing.T) {
 		Name:      "tls-policy",
 	}
 	ancestorRef := gwv1.ParentReference{
-		Group:     ptrTo(gwv1.Group(gwv1.GroupVersion.Group)),
-		Kind:      ptrTo(gwv1.Kind("Gateway")),
-		Namespace: ptrTo(gwv1.Namespace("default")),
+		Group:     new(gwv1.Group(gwv1.GroupVersion.Group)),
+		Kind:      new(gwv1.Kind("Gateway")),
+		Namespace: new(gwv1.Namespace("default")),
 		Name:      gwv1.ObjectName("gw"),
 	}
 
@@ -71,9 +71,4 @@ func TestBuildPolicyStatusPrefersPluginBuilder(t *testing.T) {
 			"plugin-specific policy status selection should not mutate the report map",
 		)
 	}
-}
-
-//go:fix inline
-func ptrTo[T any](v T) *T {
-	return new(v)
 }

--- a/pkg/reports/reporter.go
+++ b/pkg/reports/reporter.go
@@ -95,6 +95,38 @@ func NewReportMap() ReportMap {
 	}
 }
 
+func (r ReportMap) CloneGatewayReports() ReportMap {
+	out := NewReportMap()
+	for key, report := range r.Gateways {
+		out.Gateways[key] = report.Clone()
+	}
+	return out
+}
+
+func (g *GatewayReport) Clone() *GatewayReport {
+	if g == nil {
+		return nil
+	}
+	out := &GatewayReport{
+		conditions:           slices.Clone(g.conditions),
+		observedGeneration:   g.observedGeneration,
+		attachedListenerSets: g.attachedListenerSets,
+	}
+	if g.listeners != nil {
+		out.listeners = make(map[string]*ListenerReport, len(g.listeners))
+		for name, listener := range g.listeners {
+			if listener == nil {
+				out.listeners[name] = nil
+				continue
+			}
+			out.listeners[name] = &ListenerReport{
+				Status: cloneListenerStatus(listener.Status),
+			}
+		}
+	}
+	return out
+}
+
 func key(obj metav1.Object) types.NamespacedName {
 	return types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
 }

--- a/pkg/reports/reporter_test.go
+++ b/pkg/reports/reporter_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Reporting Infrastructure", func() {
 			Expect(meta.FindStatusCondition(status.Conditions, string(gwv1.GatewayConditionInsecureFrontendValidationMode))).To(BeNil())
 		})
 
-		It("should preserve controller-managed invalid parameters accepted conditions", func() {
+		It("should not preserve stale reporter-owned invalid parameters accepted conditions", func() {
 			gw := gw()
 			gw.Status.Conditions = append(gw.Status.Conditions, metav1.Condition{
 				Type:   string(gwv1.GatewayConditionAccepted),
@@ -164,8 +164,8 @@ var _ = Describe("Reporting Infrastructure", func() {
 			Expect(status).NotTo(BeNil())
 			condition := meta.FindStatusCondition(status.Conditions, string(gwv1.GatewayConditionAccepted))
 			Expect(condition).NotTo(BeNil())
-			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
-			Expect(condition.Reason).To(Equal(string(gwv1.GatewayReasonInvalidParameters)))
+			Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+			Expect(condition.Reason).To(Equal(string(gwv1.GatewayReasonAccepted)))
 		})
 
 		It("should correctly set negative gateway conditions from report and not add extra conditions", func() {

--- a/pkg/reports/status.go
+++ b/pkg/reports/status.go
@@ -106,7 +106,7 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway, attached
 	handleInvalidAddresses(gwReport, &gw)
 	handleInsecureFrontendValidationMode(gwReport, &gw)
 
-	addMissingGatewayConditions(r.Gateway(&gw), &gw)
+	addMissingGatewayConditions(r.Gateway(&gw))
 
 	finalConditions := make([]metav1.Condition, 0)
 	for _, gwCondition := range gwReport.GetConditions() {
@@ -211,12 +211,6 @@ func isReporterOwnedGatewayConditionType(conditionType gwv1.GatewayConditionType
 func shouldPreserveGatewayCondition(condition metav1.Condition, finalConditions []metav1.Condition) bool {
 	if meta.FindStatusCondition(finalConditions, condition.Type) != nil {
 		return false
-	}
-
-	if condition.Type == string(gwv1.GatewayConditionAccepted) &&
-		condition.Status == metav1.ConditionFalse &&
-		condition.Reason == string(gwv1.GatewayReasonInvalidParameters) {
-		return true
 	}
 
 	return !isReporterOwnedGatewayConditionType(gwv1.GatewayConditionType(condition.Type))
@@ -549,14 +543,8 @@ func ParentString(ref gwv1.ParentReference) string {
 // Reports will initially only contain negative conditions found during translation,
 // so all missing conditions are assumed to be positive. Here we will add all missing conditions
 // to a given report, i.e. set healthy conditions
-func addMissingGatewayConditions(gwReport *GatewayReport, gw *gwv1.Gateway) {
-	// If the existing Gateway status contains an Accepted=False with Reason=InvalidParameters,
-	// we don't want to override it with a true Accepted status. The controller will set Accepted=True
-	// when the GatewayParameters are valid again. Otherwise there is a race condition between the controller and reporter.
-	// HACK: This is because both the controller and reporter set Accepted status.
-	existingAccepted := meta.FindStatusCondition(gw.Status.Conditions, string(gwv1.GatewayConditionAccepted))
-	hasInvalidParams := existingAccepted != nil && existingAccepted.Status == metav1.ConditionFalse && existingAccepted.Reason == string(gwv1.GatewayReasonInvalidParameters)
-	if !hasInvalidParams && meta.FindStatusCondition(gwReport.GetConditions(), string(gwv1.GatewayConditionAccepted)) == nil {
+func addMissingGatewayConditions(gwReport *GatewayReport) {
+	if meta.FindStatusCondition(gwReport.GetConditions(), string(gwv1.GatewayConditionAccepted)) == nil {
 		gwReport.SetCondition(reporter.GatewayCondition{
 			Type:    gwv1.GatewayConditionAccepted,
 			Status:  metav1.ConditionTrue,


### PR DESCRIPTION
# Description

Fixes the Gateway status ownership issue behind PR 14265 by routing deployer/controller Gateway condition updates through the leader `StatusSyncer` instead of having the Gateway controller directly write `Gateway.status.conditions`.

Previously, invalid `GatewayParameters` could cause the gateway controller and translator/status syncer to fight over `Accepted` status. This change gives `StatusSyncer` a first-class controller-report queue, stores controller-owned Gateway condition reports as an overlay, and merges that overlay with the latest translation report before writing Gateway status. Status-only Gateway updates can now remain ignored by KRT translation without depending on a write-fight to preserve `Accepted=False/InvalidParameters`.

Also removes the old `BuildGWStatus` preservation hack for live `InvalidParameters` status, adds regression coverage for controller report merge/clear behavior, and keeps `go fix` cleanup complete.

# Change Type

/kind fix

# Changelog

```release-note
Fixed Gateway status thrashing when invalid GatewayParameters are reported by routing controller Gateway condition reports through the status syncer instead of relying on competing Gateway status writers.
```

# Additional Notes